### PR TITLE
Diag dest1

### DIFF
--- a/work_on_Jordan.v
+++ b/work_on_Jordan.v
@@ -191,101 +191,42 @@ induction sizes.
     and use induction accordingly **)
 Lemma diag_destruct s F:
   forall i j: 'I_(size_sum s).+1,
-  (exists k (l:'I_(size_sum s).+1) m n, 
-  (diag_block_mx s F) i j = F k l m n) \/ 
+  (exists k l m n,
+  (diag_block_mx s F) i j = F k l m n) \/
     (diag_block_mx s F) i j = 0 :> (complex R).
 Proof.
-intros.
-induction s.
-+ right. simpl. by rewrite !mxE.
-  (* exists 0%N. exists 0. exists 0. exists 0.
-  simpl. right. by rewrite !mxE. *)
-+ simpl. induction s. 
-  - simpl. left. exists a. exists 0. exists i. exists j.
-    by [].
-  -  (** Start splitting i and j from here **)
-    
-     assert ( (i<a)%N \/ (i>=a)%N).
-     { admit. }
-     destruct H.
-     * assert ( (j<a)%N \/ ( j >=a)%N).
-       { admit. }
-       destruct H0.
-       { (** Case 1 : i < a and j < a : 
-          we are in the top left block **)
-          left. exists a. exists 0.  admit.
-       }
-       { (** Case 2: i <a and j >=a:
-          we are in the top right block which is 0 **)
-          right. simpl. admit. 
-       }
-     * assert ( (j<a)%N \/ ( j >=a)%N).
-       { admit. }
-       destruct H0.
-       { (** Case 3: i>=a and j < a:
-          we are in the botton left block which is 0 **)
-          right. simpl. admit.
-       }
-       { (** Case 4: i >=a and j>=a: we are in the bottom
-          right block. This should be solved using the 
-          induction hypothesis **)
-          left. admit.
-       }
-  
- 
-    (*exists a. exists i.  *)
-   (** Need to figure out how to resolve
-      'I_(size_sum [::a, a0 & s].+1 as 
-      'I_a.+1 and 'I_(size_sum [a0 :: s].+1
-    **)
+case: s => [ | s0 s]; first by right; rewrite /= mxE.
+rewrite /diag_block_mx.
+elim: s s0 F => [ | s1 s Ih] s0 F /= i j.
+  by left; exists s0, 0%N, i, j.
+have shifts (x : 'I_(s0 + (size_sum_rec s1 s).+1).+1) :
+   (forall (xles0 : (x < s0.+1)%N), x = lshift _ (Ordinal xles0)) *
+   (forall (xgts0 : (s0 < x)%N), x = rshift s0.+1
+             (inord (x - s0.+1) : 'I_(size_sum_rec s1 s).+1)).
+  split;[by move=> xles0; apply/val_inj | ].
+  move=> xgts0; have xltsum : (x - s0.+1 < (size_sum_rec s1 s).+1)%N.
+    by rewrite ltn_subLR //; case: (x).
+  by apply/val_inj; rewrite /= inordK // subnKC.
+case : (ltnP i s0.+1)=> [ilts0 | iges0];
+  case : (ltnP j s0.+1)=> [jlts0 | jges0].
+- left; exists s0, 0%N, (Ordinal ilts0), (Ordinal jlts0)=> /=.
+  rewrite [in LHS]((shifts _).1 ilts0) [in LHS]((shifts _).1 jlts0).
+  by rewrite [LHS]block_mxEul.
+- right.
+  rewrite [in LHS]((shifts _).1 ilts0) [in LHS]((shifts _).2 jges0).
+  by rewrite [LHS]block_mxEur mxE.
+- right.
+  rewrite [in LHS]((shifts _).2 iges0) [in LHS]((shifts _).1 jlts0).
+  by rewrite [LHS]block_mxEdl mxE.
+have := ((shifts _).2 iges0); have := ((shifts _).2 jges0).
+set i' := inord (i - s0.+1); set j' := inord (j - s0.+1)=> jq iq.
+have := (Ih s1 (fun m i => F m i.+1) i' j').
+case => [[k [l [m [n Main]]]] | Main]; last first.
+  by right; rewrite iq jq [LHS]block_mxEdr.
+left; exists k, l.+1, m, n.
+by rewrite iq jq [LHS]block_mxEdr.
+Qed.
 
-    (*
-    assert ( size_sum [:: a, a0 & s] = size_sum_rec a (a0::s)).
-    { by unfold size_sum. }
-    assert ( size_sum_rec a (a0 :: s) = (a + (size_sum_rec a0 s).+1)%N).
-    { by []. } rewrite H0 in H. clear H0.
-    move: i j. rewrite H=> i j.
-
-    *)
-
-
-    (** As a temporary fix, I provided 0 and 0 as a witness
-      here. Need to replace it with a generic i and j of
-      type: 'I_a.+1
-    **) 
-    (*
-    exists 0. exists 0.
-    simpl. 
-
-    assert ( (i<a)%N \/ (i >= a)%N). 
-    { admit. }
-    destruct H.
-    * assert ( (j<a)%N \/ (j >= a)%N). 
-      { admit. }
-      destruct H0.
-      {  (** This is the case when we are looking at the 
-          top left block which is (F a 0) **)
-        left. admit. 
-      }
-      { (** This is the case where we are looking at the 
-            bottom left block which  is 0 **)
-        right. admit.
-      }
-    * assert ( (j<a)%N \/ (j >= a)%N).
-      { admit. }
-      destruct H0.
-      { (** This is the case when we are looking at the 
-          top right block which is 0 **)
-        right. admit.
-      }
-      { (** This is the case when we are looking at the bottom
-          right block which is the rest of the block and
-          induction step holds here **)
-        admit.
-      }
-
-      *)
-Admitted.
 
 Lemma C_mod_0: C_mod 0 = 0%Re.
 Proof.


### PR DESCRIPTION
This is the proof you inquired about yesterday morning.
- Please note that the second existentially quantified variable is a natural number, not a bounded natural or ordinal number (this number is a position is sequence s, it is not related to the size of the final matrix).
- There is only one case analysis and one proof by induction, because the function `diag_block_mx` is not recursive (a case analysis suffices) and the function `diag_block_mx_rec` is recursive (this one requires a proof by induction.
- The induction must be loaded with s0 and F, because these parameters change in recursive calls.
- There is a coercion from bounded natural numbers (of type `'I_n`) to natural numbers, you can thus use bounded natural numbers is expressions where natural numbers are expected (as in ltnP).  This coercion is called `nat_of_ord`, but there is a general interface for subtypes which gives the name `val` to such coercions.  Moreover, this kind of `val` function is known to be injective.  This is very important, and used in this proof: when we need to compare two bounded natural numbers (aka ordinals in math-comp parlance).
- `diag_block_mx_rec` uses `block_mx` in a fundamental way.  to reason about coefficients of `block_mx` matrices, the key lemmas are `block_mxE(ul,ur,dl,dr)`: they require that we show the `i` `j` indices are equal to `rshift` or `lshift` instances.  These shift proofs are done once and for all in the `shifts` sublemma.
- Even so, the `rewrite` tactic does not recognize that the `block_mxE` lemmas can rewrite, so we need to be very precise by telling the system *where* to perform the rewrite.  The reason for the failure is that the types of the matrices don't match exactly (one type appears as `(_ + _).+1`, the other as `(_.+1 + _)`, the two are convertible but not syntactically the same, and `rewrite` cares about syntactic shape).